### PR TITLE
Output comment text more faithfully to allow conditional comments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,7 @@ function walk (tree, options) {
 
     // comment node type
     if (node.type === 'comment') {
-      m += `<!-- ${escape(node.content.trim())} -->`
+      m += `<!--${escape(node.content)}-->`
       return m
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -36,10 +36,20 @@ test('comment', (t) => {
   const res = generator([
     {
       type: 'comment',
-      content: 'test comment'
+      content: ' test comment '
     }
   ])
   t.truthy(res() === '<!-- test comment -->')
+})
+
+test('ie conditional comment', (t) => {
+  const res = generator([
+    {
+      type: 'comment',
+      content: '[if IE]> test ie content <![endif]'
+    }
+  ])
+  t.truthy(res() === '<!--[if IE]> test ie content <![endif]-->')
 })
 
 test('runtime', (t) => {


### PR DESCRIPTION
Existing comment output inserts spaces that break IE conditional comments. As the conditional comment syntax is valid HTML, code-gen should output valid comments faithfully.